### PR TITLE
Add immediate_send possibility

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -119,6 +119,18 @@ clients:
             # ...
 ```
 
+### Immediate send
+
+In basic usage, the data is really sent to the StatsD servers during the `kernel.terminate` event. But if you want to use this bundle in commands, you may want to send data immediately.
+
+```yaml
+clients:
+    event:
+        console.exception:
+            increment: mysite.command.<command.name>.exception
+            immediate_send: true
+```
+
 ## Collect basics metrics on your Symfony application
 
 Comparing to others bundle related to statsd, we choose not to implement the collect of those metrics natively in the bundle. But please find below some hints to do it on your own.

--- a/src/M6Web/Bundle/StatsdBundle/Client/Client.php
+++ b/src/M6Web/Bundle/StatsdBundle/Client/Client.php
@@ -43,6 +43,7 @@ class Client extends BaseClient
         }
 
         $config = $this->listenedEvents[$name];
+        $immediateSend = false;
 
         foreach ($config as $conf => $confValue) {
             // increment
@@ -52,9 +53,15 @@ class Client extends BaseClient
                 $this->addTiming($event, 'getTiming', self::replaceInNodeFormMethod($event, $confValue));
             } elseif (('custom_timing' === $conf) and is_array($confValue)) {
                 $this->addTiming($event, $confValue['method'], self::replaceInNodeFormMethod($event, $confValue['node']));
+            } elseif ('immediate_send' === $conf) {
+                $immediateSend = $confValue;
             } else {
                 throw new Exception("configuration : ".$conf." not handled by the StatsdBundle or its value is in a wrong format.");
             }
+        }
+
+        if ($immediateSend) {
+            $this->send();
         }
     }
 

--- a/src/M6Web/Bundle/StatsdBundle/DependencyInjection/Configuration.php
+++ b/src/M6Web/Bundle/StatsdBundle/DependencyInjection/Configuration.php
@@ -76,6 +76,7 @@ class Configuration implements ConfigurationInterface
                                                 ->scalarNode('method')->end()
                                             ->end()
                                         ->end()
+                                        ->booleanNode('immediate_send')->defaultFalse()->end()
                                     ->end()
                                 ->end()
                             ->end()

--- a/src/M6Web/Bundle/StatsdBundle/Tests/Units/Client/Client.php
+++ b/src/M6Web/Bundle/StatsdBundle/Tests/Units/Client/Client.php
@@ -48,10 +48,37 @@ class Client extends atoum\test
                 ->call('increment')
                     ->withArguments('stats.test')
                     ->once()
-                    ;
+                ->call('send')
+                    ->never();
 
     }
 
+    /**
+     * testHandleEventWithImmediateSend
+     */
+    public function testHandleEventWithImmediateSend()
+    {
+
+        $client = $this->getMockedClient();
+
+        $event = new \Symfony\Component\EventDispatcher\Event();
+        $event->setName('test');
+
+        $client->addEventToListen('test', array(
+            'increment'      => 'stats.<name>',
+            'immediate_send' => true,
+        ));
+
+        $this->if($client->handleEvent($event))
+            ->then
+                ->mock($client)
+                    ->call('increment')
+                        ->withArguments('stats.test')
+                        ->once()
+                    ->call('send')
+                        ->once();
+
+    }
     /**
     * test handle event with an invalid stats
     */


### PR DESCRIPTION
In console commands, the `kernel.terminate` event is never fired and we might want to send data immediately in case of long running commands.
