### PR TITLE
Add peak memory usage to ConsoleEvent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,14 @@ php:
   - 5.5
   - 5.6
 
+env:
+   - SYMFONY_VERSION=2.3.*
+   - SYMFONY_VERSION=2.7.*
+
 before_script:
   - wget http://getcomposer.org/composer.phar
-  - php composer.phar install --dev
+  - php composer.phar require symfony/symfony:${SYMFONY_VERSION} --no-update --dev
+  - php composer.phar update --prefer-dist --no-interaction --dev
 
 script:
   - vendor/bin/coke

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,7 @@
     },
     "require-dev": {
         "atoum/atoum": "@stable",
-        "symfony/event-dispatcher": "@stable",
-        "symfony/symfony": "~2.3",
+        "symfony/symfony": "2.3",
         "m6web/coke" : "~1.2",
         "m6web/symfony2-coding-standard" : "~1.2"
     },

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -41,8 +41,13 @@ class Client extends BaseClient
      * @param EventInterface $event an event
      * @param string         $name the event name
      */
-    public function handleEvent($event, $name)
+    public function handleEvent($event, $name = null)
     {
+        // this is used to stay compatible with Symfony 2.3
+        if (is_null($name)) {
+            $name = $event->getName();
+        }
+
         if (!isset($this->listenedEvents[$name])) {
             return;
         }

--- a/src/Event/ConsoleEvent.php
+++ b/src/Event/ConsoleEvent.php
@@ -94,6 +94,19 @@ abstract class ConsoleEvent extends Event
     }
 
     /**
+     * Get peak memory usage
+     *
+     * @return int
+     */
+    public function getPeakMemory()
+    {
+        $memory = memory_get_peak_usage(true);
+        $memory = ($memory > 1024 ? intval($memory / 1024) : 0);
+
+        return $memory;
+    }
+
+    /**
      * @return BaseConsoleEvent
      */
     public function getOriginalEvent()

--- a/src/Tests/Units/Client/Client.php
+++ b/src/Tests/Units/Client/Client.php
@@ -33,13 +33,12 @@ class Client extends atoum\test
         $client = $this->getMockedClient();
 
         $event = new \Symfony\Component\EventDispatcher\Event();
-        $event->setName('test');
 
         $client->addEventToListen('test', array(
             'increment' => 'stats.<name>'
         ));
 
-        $this->if($client->handleEvent($event))
+        $this->if($client->handleEvent($event, 'test'))
             ->then
             ->mock($client)
                 ->call('increment')
@@ -59,14 +58,13 @@ class Client extends atoum\test
         $client = $this->getMockedClient();
 
         $event = new \Symfony\Component\EventDispatcher\Event();
-        $event->setName('test');
 
         $client->addEventToListen('test', array(
             'increment'      => 'stats.<name>',
             'immediate_send' => true,
         ));
 
-        $this->if($client->handleEvent($event))
+        $this->if($client->handleEvent($event, 'test'))
             ->then
                 ->mock($client)
                     ->call('increment')
@@ -90,9 +88,8 @@ class Client extends atoum\test
 
         $this->exception(function () use ($client) {
             $event = new \Symfony\Component\EventDispatcher\Event();
-            $event->setName('test');
 
-            $client->handleEvent($event);
+            $client->handleEvent($event, 'test');
         });
     }
 
@@ -109,9 +106,8 @@ class Client extends atoum\test
 
         $this->exception(function () use ($client) {
             $event = new \Symfony\Component\EventDispatcher\Event();
-            $event->setName('test');
 
-            $client->handleEvent($event);
+            $client->handleEvent($event, 'test');
         });
 
         $client = $this->getMockedClient();
@@ -122,9 +118,8 @@ class Client extends atoum\test
 
         $this->exception(function () use ($client) {
             $event = new \Symfony\Component\EventDispatcher\Event();
-            $event->setName('test');
 
-            $client->handleEvent($event);
+            $client->handleEvent($event, 'test');
         });
 
     }
@@ -141,13 +136,12 @@ class Client extends atoum\test
         ));
 
         $event = new Event();
-        $event->setName('test');
 
         $client->addEventToListen('test', array(
             'timing' => 'stats.<name>'
         ));
 
-        $this->if($client->handleEvent($event))
+        $this->if($client->handleEvent($event, 'test'))
             ->then
             ->mock($client)
                 ->call('timing')
@@ -168,13 +162,12 @@ class Client extends atoum\test
         ));
 
         $event = new Event();
-        $event->setName('test');
 
         $client->addEventToListen('test', array(
             'custom_timing' => array('node' => 'stats.<name>', 'method' => 'getMemory')
         ));
 
-        $this->if($client->handleEvent($event))
+        $this->if($client->handleEvent($event, 'test'))
             ->then
             ->mock($client)
                 ->call('timing')

--- a/src/Tests/Units/Client/Event.php
+++ b/src/Tests/Units/Client/Event.php
@@ -2,7 +2,7 @@
 
 namespace M6Web\Bundle\StatsdBundle\Tests\Units\Client;
 
-class Event
+class Event extends \Symfony\Component\EventDispatcher\Event
 {
     private $name = '';
 


### PR DESCRIPTION
I had to include in this PR the removing of calls to `$event->getName()` event if this is not directly related.
This method is deprecated and made the tests to fail.

Note that these modification will only work with Symfony >= 2.4 (cf https://github.com/symfony/EventDispatcher/compare/2.3...2.4#diff-66c6352b662221adb7fcd9daf77ae032R164).