### PR TITLE
add to send limit config

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -172,6 +172,20 @@ m6_statsd:
                     immediate_send: true
 ```
 
+### To send limit
+
+You can define a limit for the queue size. When this limit is reached, the client automatically send data to the StatsD servers.
+
+```yaml
+m6_statsd:
+    clients:
+        default:
+            to_send_limit: 1000
+            events:
+                console.exception:
+                    increment: mysite.command.<command.name>.exception
+```
+
 ## Console custom events
 
 This bundle can trigger custom console events that allow to get command start time and execution duration.

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -14,6 +14,8 @@ class Client extends BaseClient
 {
     protected $listenedEvents = array();
 
+    protected $toSendLimit;
+
     /**
      * getter for listenedEvents
      *
@@ -33,6 +35,20 @@ class Client extends BaseClient
     public function addEventToListen($eventName, $eventConfig)
     {
         $this->listenedEvents[$eventName] = $eventConfig;
+    }
+
+    /**
+     * Set toSend limit
+     *
+     * @param int $toSendLimit
+     *
+     * @return $this
+     */
+    public function setToSendLimit($toSendLimit)
+    {
+        $this->toSendLimit = $toSendLimit;
+
+        return $this;
     }
 
     /**
@@ -77,6 +93,12 @@ class Client extends BaseClient
             } else {
                 throw new Exception("configuration : ".$conf." not handled by the StatsdBundle or its value is in a wrong format.");
             }
+        }
+
+        if (null !== $this->toSendLimit && $this->getToSend()->count() >= $this->toSendLimit) {
+            $this->send();
+
+            return;
         }
 
         if ($immediateSend) {

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -96,9 +96,7 @@ class Client extends BaseClient
         }
 
         if (null !== $this->toSendLimit && $this->getToSend()->count() >= $this->toSendLimit) {
-            $this->send();
-
-            return;
+            $immediateSend = true;
         }
 
         if ($immediateSend) {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -84,6 +84,7 @@ class Configuration implements ConfigurationInterface
                                     ->end()
                                 ->end()
                             ->end()
+                            ->scalarNode('to_send_limit')->end()
                         ->end()
                     ->end()
                 ->end()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -84,7 +84,7 @@ class Configuration implements ConfigurationInterface
                                     ->end()
                                 ->end()
                             ->end()
-                            ->scalarNode('to_send_limit')->end()
+                            ->integerNode('to_send_limit')->min(1)->end()
                         ->end()
                     ->end()
                 ->end()

--- a/src/DependencyInjection/M6WebStatsdExtension.php
+++ b/src/DependencyInjection/M6WebStatsdExtension.php
@@ -151,6 +151,10 @@ class M6WebStatsdExtension extends Extension
         $definition->setScope(ContainerInterface::SCOPE_CONTAINER);
         $definition->addArgument($usedServers);
 
+        if (isset($config['to_send_limit'])) {
+            $definition->addMethodCall('setToSendLimit', array($config['to_send_limit']));
+        }
+
         foreach ($events as $eventName => $eventConfig) {
             $definition->addTag('kernel.event_listener', ['event' => $eventName, 'method' => 'handleEvent']);
             $definition->addMethodCall('addEventToListen', [$eventName, $eventConfig]);


### PR DESCRIPTION
This PR add a `toSendLimit` configuration for the client.
When this limit is reached, the client automatically send data to statsd.

It is useful for tasks with very high amount of events triggered. 