### PR TITLE
Fire specific event for non-0 exit status command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
     "config": {
         "vendor-dir": "vendor"
     },
-    "minimum-stability" : "dev",
     "require": {
         "php": ">=5.4.0",
         "symfony/property-access" : ">=2.2",
@@ -22,11 +21,11 @@
     },
     "require-dev": {
         "atoum/atoum": "@stable",
-        "symfony/symfony": "2.3",
+        "symfony/symfony": "~2.3",
         "m6web/coke" : "~1.2",
         "m6web/symfony2-coding-standard" : "~1.2"
     },
-	"autoload": {
+    "autoload": {
         "psr-4": { "M6Web\\Bundle\\StatsdBundle\\": "src/" }
     }
 }

--- a/src/Event/ConsoleEvent.php
+++ b/src/Event/ConsoleEvent.php
@@ -11,6 +11,7 @@ abstract class ConsoleEvent extends Event
 {
     const COMMAND   = 'm6web.console.command';
     const TERMINATE = 'm6web.console.terminate';
+    const ERROR     = 'm6web.console.error';
     const EXCEPTION = 'm6web.console.exception';
 
     /**

--- a/src/Event/ConsoleEvent.php
+++ b/src/Event/ConsoleEvent.php
@@ -136,13 +136,15 @@ abstract class ConsoleEvent extends Event
      * @param float            $executionTime
      *
      * @return ConsoleEvent
+     *
+     * @throws \InvalidArgumentException
      */
     public static function createFromConsoleEvent(BaseConsoleEvent $e, $startTime = null, $executionTime = null)
     {
         if (static::support($e)) {
             return new static($e, $startTime, $executionTime);
         } else {
-            throw \InvalidArgumentException('Invalid envent type.');
+            throw \InvalidArgumentException('Invalid event type.');
         }
     }
 

--- a/src/Listener/ConsoleListener.php
+++ b/src/Listener/ConsoleListener.php
@@ -6,6 +6,7 @@ use M6Web\Bundle\StatsdBundle\Event\ConsoleEvent;
 
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Console\Event\ConsoleEvent as BaseConsoleEvent;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 
 /**
  * Listen to symfony command events
@@ -46,10 +47,15 @@ class ConsoleListener
     }
 
     /**
-     * @param BaseConsoleEvent $e
+     * @param ConsoleTerminateEvent $e
      */
-    public function onTerminate(BaseConsoleEvent $e)
+    public function onTerminate(ConsoleTerminateEvent $e)
     {
+        // For non-0 exit command, fire an ERROR event
+        if ($e->getExitCode() != 0) {
+            $this->dispatch(ConsoleEvent::ERROR, $e);
+        }
+
         $this->dispatch(ConsoleEvent::TERMINATE, $e);
     }
 

--- a/src/Tests/Units/Listener/ConsoleListener.php
+++ b/src/Tests/Units/Listener/ConsoleListener.php
@@ -50,6 +50,20 @@ class ConsoleListener extends atoum\test
                 ]
             ],
             [
+                'onTerminate',
+                new \Symfony\Component\Console\Event\ConsoleTerminateEvent($command, $input, $output, -1),
+                [
+                    [
+                        'name'  => ConsoleEvent::TERMINATE,
+                        'class' => 'M6Web\Bundle\StatsdBundle\Event\ConsoleTerminateEvent'
+                    ],
+                    [
+                        'name'  => ConsoleEvent::ERROR,
+                        'class' => 'M6Web\Bundle\StatsdBundle\Event\ConsoleTerminateEvent'
+                    ]
+                ]
+            ],
+            [
                 'onException',
                 new \Symfony\Component\Console\Event\ConsoleExceptionEvent($command, $input, $output, $exception, 0),
                 [

--- a/src/Tests/Units/Listener/ConsoleListener.php
+++ b/src/Tests/Units/Listener/ConsoleListener.php
@@ -13,85 +13,93 @@ use M6Web\Bundle\StatsdBundle\Event\ConsoleEvent;
 */
 class ConsoleListener extends atoum\test
 {
-    protected $dispatcher;
-
-    public function getBaseInstance()
+    public function getMockedDispatcher()
     {
-        $listener   = new Base;
-
-        $this->dispatcher = new \mock\Symfony\Component\EventDispatcher\EventDispatcher;
-        $this->dispatcher->addListener(BaseConsoleEvent::COMMAND, [$listener, 'onCommand']);
-        $this->dispatcher->addListener(BaseConsoleEvent::TERMINATE, [$listener, 'onTerminate']);
-        $this->dispatcher->addListener(BaseConsoleEvent::EXCEPTION, [$listener, 'onException']);
-
-        $listener->setEventDispatcher($this->dispatcher);
-
-        return $listener;
-    }
-
-    public function triggerConsoleEvent($eventName, $eventClass)
-    {
-        $eventClass = '\mock\\'.$eventClass;
-
-        $this->mockGenerator->orphanize('__construct');
-        $this->mockGenerator->shuntParentClassCalls();
-
-        $event = new $eventClass;
-
-        $this->dispatcher->dispatch($eventName, $event);
+        return new \mock\Symfony\Component\EventDispatcher\EventDispatcher();
     }
 
     public function eventDataProvider()
     {
+        $this->mockGenerator->orphanize('__construct');
+        $this->mockGenerator->shuntParentClassCalls();
+
+        $command    = new \mock\Symfony\Component\Console\Command\Command;
+        $input      = new \mock\Symfony\Component\Console\Input\InputInterface;
+        $output     = new \mock\Symfony\Component\Console\Output\OutputInterface;
+        $exception  = new \mock\Exception();
+
         return [
             [
-                BaseConsoleEvent::COMMAND,
-                'Symfony\Component\Console\Event\ConsoleCommandEvent',
-                ConsoleEvent::COMMAND,
-                'M6Web\Bundle\StatsdBundle\Event\ConsoleCommandEvent'
+                'onCommand',
+                new \Symfony\Component\Console\Event\ConsoleCommandEvent($command, $input, $output),
+                [
+                    [
+                        'name'  => ConsoleEvent::COMMAND,
+                        'class' => 'M6Web\Bundle\StatsdBundle\Event\ConsoleCommandEvent'
+                    ]
+                ]
             ],
             [
-                BaseConsoleEvent::TERMINATE,
-                'Symfony\Component\Console\Event\ConsoleTerminateEvent',
-                ConsoleEvent::TERMINATE,
-                'M6Web\Bundle\StatsdBundle\Event\ConsoleTerminateEvent'
+                'onTerminate',
+                new \Symfony\Component\Console\Event\ConsoleTerminateEvent($command, $input, $output, 0),
+                [
+                    [
+                        'name'  => ConsoleEvent::TERMINATE,
+                        'class' => 'M6Web\Bundle\StatsdBundle\Event\ConsoleTerminateEvent'
+                    ]
+                ]
             ],
             [
-                BaseConsoleEvent::EXCEPTION,
-                'Symfony\Component\Console\Event\ConsoleExceptionEvent',
-                ConsoleEvent::EXCEPTION,
-                'M6Web\Bundle\StatsdBundle\Event\ConsoleExceptionEvent'
+                'onException',
+                new \Symfony\Component\Console\Event\ConsoleExceptionEvent($command, $input, $output, $exception, 0),
+                [
+                    [
+                        'name'  => ConsoleEvent::EXCEPTION,
+                        'class' =>'M6Web\Bundle\StatsdBundle\Event\ConsoleExceptionEvent'
+                    ]
+                ]
             ],
         ];
     }
 
     /**
      * @dataProvider eventDataProvider
+     *
+     * @param string           $methodName  Method name to call
+     * @param BaseConsoleEvent $baseEvent   Event fired from Symfony console command
+     * @param array            $firedEvents Array who contains each new events fired from the $baseEvent dispatching
      */
-    public function testEvent($baseEvent, $baseEventClass, $newEvent, $newEventClass)
+    public function testEvent($methodName, $baseEvent, $firedEvents)
     {
-        $self     = $this;
-        $listener = $this->getBaseInstance();
+        $self = $this;
+        $dispatcher = $this->getMockedDispatcher();
 
+        // Check, during the event firing, that the event is created from base event
+        foreach($firedEvents as $firedEvent) {
+            $dispatcher
+                ->addListener(
+                    $firedEvent['name'],
+                    function ($event) use ($self, $baseEvent, $firedEvent) {
+                        $self
+                            ->object($event)
+                                ->isInstanceOf($firedEvent['class'])//
+                            ->object($event->getOriginalEvent())
+                                ->isIdenticalTo($baseEvent);
+                    }
+                );
+        }
+
+        // Here is the code to initialize and fire event, but real test is just above
         $this
-            ->dispatcher
-            ->addListener(
-                $newEvent,
-                function($event) use($self, $newEventClass) {
-                    $self
-                        ->object($event)
-                            ->isInstanceOf($newEventClass)
-                    ;
-                }
+            ->given(
+                $base = new Base(),
+                $base->setEventDispatcher($dispatcher)
             )
-        ;
-
-        $this->triggerConsoleEvent($baseEvent,$baseEventClass);
-
-        $this
-            ->mock($this->dispatcher)
-                ->call('dispatch')
-                    ->twice()
+            ->if($base->{$methodName}($baseEvent))
+            ->then
+                ->mock($dispatcher)
+                    ->call('dispatch')
+                        ->exactly(count($firedEvents))
         ;
     }
 }


### PR DESCRIPTION
With this PR, a command who finish with a non-0 exit status will lead to fire a specific event in StatsBundle : `m6web.command.error`, in addition to `m6web.command.terminate` event who is ever fired at command exit.

There is 2 limits with this PR : 
* the command's developper has to explicitly return non-0 exit status to consider the command's execution as failed
* a fatal error in the command do not lead to any event's fire.