### PR TITLE
refactor Client avoid non-necessary object creation

### DIFF
--- a/src/DependencyInjection/M6WebStatsdExtension.php
+++ b/src/DependencyInjection/M6WebStatsdExtension.php
@@ -8,6 +8,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\PropertyAccess;
 
 /**
  * This is the class that loads and manages your bundle configuration
@@ -152,13 +153,15 @@ class M6WebStatsdExtension extends Extension
         $definition->addArgument($usedServers);
 
         if (isset($config['to_send_limit'])) {
-            $definition->addMethodCall('setToSendLimit', array($config['to_send_limit']));
+            $definition->addMethodCall('setToSendLimit', [$config['to_send_limit']]);
         }
 
         foreach ($events as $eventName => $eventConfig) {
             $definition->addTag('kernel.event_listener', ['event' => $eventName, 'method' => 'handleEvent']);
             $definition->addMethodCall('addEventToListen', [$eventName, $eventConfig]);
         }
+
+        $definition->addMethodCall('setPropertyAccessor', [PropertyAccess\PropertyAccess::createPropertyAccessorBuilder()->enableMagicCall()->getPropertyAccessor()]);
 
         $container->setDefinition($serviceId, $definition);
 

--- a/src/Tests/Units/Client/Client.php
+++ b/src/Tests/Units/Client/Client.php
@@ -4,6 +4,7 @@ namespace M6Web\Bundle\StatsdBundle\Tests\Units\Client;
 
 use mageekguy\atoum;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\PropertyAccess;
 
 /**
 * Client class
@@ -115,6 +116,8 @@ class Client extends atoum\test
     public function testHandleEventWithInvalidConfigIncrement()
     {
         $client = $this->getMockedClient();
+
+        $client->setPropertyAccessor(PropertyAccess\PropertyAccess::createPropertyAccessorBuilder()->enableMagicCall()->getPropertyAccessor());
 
         $client->addEventToListen('test', array(
             'increment' => 'stats.<toto>'


### PR DESCRIPTION
fixes #41 

involve just one creation of the property accessor.
