### PR TITLE
Send last statsd data on console.terminate

### DIFF
--- a/src/DependencyInjection/M6WebStatsdExtension.php
+++ b/src/DependencyInjection/M6WebStatsdExtension.php
@@ -178,6 +178,11 @@ class M6WebStatsdExtension extends Extension
             'method'   => 'onKernelTerminate',
             'priority' => -100
         ]);
+        $definition->addTag('kernel.event_listener', [
+            'event'    => 'console.terminate',
+            'method'   => 'onConsoleTerminate',
+            'priority' => -100
+        ]);
 
         if ($baseEvents) {
             $definition->addTag('kernel.event_listener', [

--- a/src/Statsd/Listener.php
+++ b/src/Statsd/Listener.php
@@ -2,6 +2,7 @@
 
 namespace M6Web\Bundle\StatsdBundle\Statsd;
 
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Event\PostResponseEvent;
@@ -55,6 +56,18 @@ class Listener
      * @return void
      */
     public function onKernelTerminate(PostResponseEvent $event)
+    {
+        $this->statsdClient->send();
+    }
+
+    /**
+     * method called on the console.terminate event
+     *
+     * @param ConsoleTerminateEvent $event event
+     *
+     * @return void
+     */
+    public function onConsoleTerminate(ConsoleTerminateEvent $event)
     {
         $this->statsdClient->send();
     }


### PR DESCRIPTION
When a console command is run, there is no `kernel.terminate` event sent, only `console.terminate`. Unfortunately we need to catch these kind of events in order to flush remaining statsd data.

Just added corresponding listener.