### PR TITLE
Implement reset() method in StatsdDataCollector

### DIFF
--- a/src/DataCollector/StatsdDataCollector.php
+++ b/src/DataCollector/StatsdDataCollector.php
@@ -27,11 +27,13 @@ class StatsdDataCollector extends DataCollector
      */
     public function reset()
     {
-        $this->statsdClients      = [];
-        $this->data['clients']    = [];
-        $this->data['operations'] = 0;
+        $this->statsdClients = [];
+        $this->data = [
+            'clients' => [],
+            'operations' => 0,
+        ];
     }
-    
+
     /**
      * Kernel event
      *

--- a/src/DataCollector/StatsdDataCollector.php
+++ b/src/DataCollector/StatsdDataCollector.php
@@ -19,11 +19,19 @@ class StatsdDataCollector extends DataCollector
      */
     public function __construct()
     {
+        $this->reset();
+    }
+
+    /**
+     * Reset the data collector to initial state
+     */
+    public function reset()
+    {
         $this->statsdClients      = [];
         $this->data['clients']    = [];
         $this->data['operations'] = 0;
     }
-
+    
     /**
      * Kernel event
      *


### PR DESCRIPTION
After upgrade to Symfony 3.4, there is a deprecation error caused by this class:

> Implementing "Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface" without the "reset()" method is deprecated since Symfony 3.4 and will be unsupported in 4.0 for class "M6Web\Bundle\StatsdBundle\DataCollector\StatsdDataCollector"

This PR introduces what the deprecation notice asks for.