### PR TITLE
Allow Symfony 3.4 before bumping v3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ php:
   - 7.2
 
 env:
-   - SYMFONY_VERSION=4.0.*
+  - SYMFONY_VERSION=3.4.0
+  - SYMFONY_VERSION=4.0.*
 
 before_script:
   - wget http://getcomposer.org/composer.phar

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ StatsdBundle [![Build Status](https://travis-ci.org/M6Web/StatsdBundle.png?branc
 
 ## Bundle easing the [statsd](https://github.com/etsy/statsd/) usage.
 
+This bundle currently supports `php >=7.1.3` and `symfony 3.4/4.x`.
+
+If you need support for `php >=5.4.0` and `symfony 2.x/3.x`, use version [v2.15.1](https://github.com/M6Web/StatsdBundle/tree/v2.15.1).
+
  * [about](doc/about.md)
  * [installation](doc/installation.md)
  * [usage](doc/usage.md)

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
     },
     "require": {
         "php": "^7.1.3",
-        "symfony/property-access": "^4.0",
+        "symfony/property-access": "^3.4 || ^4.0",
         "m6web/statsd": "^1.3"
     },
     "require-dev": {
         "atoum/atoum": "^2.8|^3.0",
-        "symfony/symfony": "~4.0",
+        "symfony/symfony": "^3.4 || ^4.0",
         "m6web/coke" : "~1.2",
         "m6web/symfony2-coding-standard" : "~1.2"
     },


### PR DESCRIPTION
## Why
Because we're about to bump a new release `v3.0.0` since we've merged #64 
but before that we should allow users of this new bundle version to run it on Symfony 3.4 (as this is the same as Symfony 4.0 anyway)