### PR TITLE
Remove "version" from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
     "description" : "Add statds metrics in your symfony app. Allow you to bind metrics on any symfony event.",
     "type": "symfony-bundle",
     "license": "MIT",
-    "version": "3.0.0",
     "keywords": ["symfony", "bundle", "statsd", "m6web"],
     "authors": [
         {


### PR DESCRIPTION
## Why?
This was added in #64 but it cause issues in our release process.

We're used to push a new tag on GitHub like `v3.0.0` and let Packagist's hook fetch this new tag on its side.

But since there is a `version` key in our `composer.json` file, Packagist does not care about our tag, it only depends on our `version` key... which is error prone (because I'm sure we'll forget to update the `version` key before tagging our new version).

=> https://packagist.org/packages/m6web/statsd-bundle#3.0.0 proves that Packagist does not rely on our tags name anymore. (`3.0.0` vs `v3.0.0`)

## How?
- Remove the `version` key from `composer.json`