### PR TITLE
Fix a test namespace and include them in dev classmap only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: php
 php:
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4
 
 env:
   - SYMFONY_VERSION=3.4.0

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "m6web/statsd-bundle",
-    "description" : "Add statds metrics in your symfony app. Allow you to bind metrics on any symfony event.",
+    "description" : "Add statsd metrics in your symfony app. Allow you to bind metrics on any symfony event.",
     "type": "symfony-bundle",
     "license": "MIT",
     "keywords": ["symfony", "bundle", "statsd", "m6web"],
@@ -27,6 +27,16 @@
         "m6web/symfony2-coding-standard" : "~1.2"
     },
     "autoload": {
-        "psr-4": { "M6Web\\Bundle\\StatsdBundle\\": "src/" }
+        "psr-4": {
+            "M6Web\\Bundle\\StatsdBundle\\": "src/"
+        },
+        "exclude-from-classmap": [
+            "src/Tests/"
+        ]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "M6Web\\Bundle\\StatsdBundle\\Tests\\": "src/Tests/"
+        }
     }
 }

--- a/src/Tests/Units/DependencyInjection/M6WebStatsdExtension.php
+++ b/src/Tests/Units/DependencyInjection/M6WebStatsdExtension.php
@@ -1,5 +1,5 @@
 <?php
-namespace M6Web\Bundle\StatsdBundle\DependencyInjection\tests\units;
+namespace M6Web\Bundle\StatsdBundle\Tests\Units\DependencyInjection;
 
 use mageekguy\atoum;
 use Symfony\Component\Config\FileLocator;


### PR DESCRIPTION
There is a wrong namespace in a test which produces this message:

```
Deprecation Notice: Class M6Web\Bundle\StatsdBundle\DependencyInjection\tests\units\M6WebStatsdExtension located in vendor/m6web/statsd-bundle/src\Tests\Units\DependencyInjection\M6WebStatsd
Extension.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0.
```

The pull request fixes it and excludes tests from autoload similar as in https://github.com/M6Web/Statsd/pull/28