### PR TITLE
Force `str_replace` value to be a string

### DIFF
--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -188,7 +188,7 @@ class Client extends BaseClient
             $tokens = $matches[1];
             foreach ($tokens as $token) {
                 $value = $this->propertyAccessor->getValue($event, $token);
-                $string = str_replace('<'.$token.'>', $value, $string);
+                $string = str_replace('<'.$token.'>', (string) $value, $string);
             }
         }
 


### PR DESCRIPTION
For example, with the `statsd.exception` key, the value might be an `int`. As you declare `strict_types`, PHP will throw if the value is not an array or an int.

This PR propose to convert the value to a string every time.

A possible fix for this case exclusively might be to change https://github.com/BedrockStreaming/StatsdBundle/blob/c00c1f31ded50234e1ef17d57819f6cbf0ab26c5/src/Statsd/Listener.php#L46

```diff
-             new StatsdEvent($code ?? 'unknown'),
+             new StatsdEvent((string) $code ?? 'unknown'),
```

But it will only handle exception, and not all possible value returned as int.